### PR TITLE
add smooth transition on 'About Us' section imgs

### DIFF
--- a/ABOUT_US/css/style.css
+++ b/ABOUT_US/css/style.css
@@ -540,6 +540,7 @@ mark,
 .img-fluid {
   max-width: 100%;
   height: auto;
+  transition: all .3s ease;
 }
 
 .img-thumbnail {


### PR DESCRIPTION
Added a smooth transition on the cards of the `About Us` section.

`Preview of the new hover transition:`


https://user-images.githubusercontent.com/94648837/195526935-e9f156d6-0fcc-4236-9816-6d9534c33fb3.mov

